### PR TITLE
Add config reader action

### DIFF
--- a/.github/actions/read_config/action.yml
+++ b/.github/actions/read_config/action.yml
@@ -1,0 +1,19 @@
+name: Read Config
+description: Reads a JSON configuration and populates the GHA environment accordingly
+
+inputs:
+  config:
+    description: The location of the configuration file
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Push to env
+      shell: bash
+      id: putsh_to_env
+      run: |
+        for OUTPUT in $(cat ${{ inputs.config }} | jq 'keys[] as $k | "\($k)=\(.[$k])"' | tr -d '"')
+        do
+          echo $OUTPUT >> $GITHUB_ENV
+        done


### PR DESCRIPTION
Adds an action that can read JSON-formatted configuration files and convert the contents to environment variables. Example usage:

- The configuration file (for example at `config/config.json`) should contain a JSON object of key-value pairs where the key is the environment variable name.
- For example:
```json
{
  "ENV_VAR": "ENV_VAL",
  "FOO": "BAR"
}
```
- The action ca be used as follows:
```yaml
jobs:
  sample-job:
    name: Populate the environment
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
      - uses: ./.github/actions/config
        with:
            config: config/config.json
      - run: |
          ...
```
- In the case above, the last step of `sample-job` would have the following `env`:
```
  env:
    ENV_VAR: ENV_VAL
    FOO: BAR
```